### PR TITLE
Integrating with bintray-sbt to publish to Bintray

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,12 @@ Deprecated methods since Akka 2.3.4 are NOT implemented. As a result, some tests
 Rest of methods are tested with the test harness included in this project.  
 
 ## Quick start guide
-### Installation 
+### Installation
+plugins.sbt
+```
+resolvers += Resolver.url("akka-persistence-redis", url("http://dl.bintray.com/ssongvan/maven"))(Resolver.ivyStylePatterns)
+```
+build.sbt
 ```
 libraryDependencies ++= Seq("com.hootsuite" %% "akka-persistence-redis" % "0.1.0")
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -1,12 +1,14 @@
+import sbt._
 import Version._
+import Settings._
 
 name := "akka-persistence-redis"
 
 organization := "com.hootsuite"
 
-version := "0.1.0-SNAPSHOT"
+version := Version.project
 
-scalaVersion := "2.11.7"
+scalaVersion := Version.scala
 
 libraryDependencies ++= Seq(
   "com.typesafe.akka"    %% "akka-contrib" % Version.akka,
@@ -19,3 +21,5 @@ libraryDependencies ++= Seq(
 libraryDependencies ++= Seq(
   "com.typesafe.akka"    %% "akka-persistence-tck-experimental" % Version.akka % "test"
 )
+
+Settings.publishSettings

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -1,0 +1,37 @@
+import bintray.BintrayPlugin.autoImport._
+import sbt.Keys._
+import sbt._
+import Version._
+
+object Settings {
+  lazy val publishSettings =
+    if (Version.project.endsWith("-SNAPSHOT"))
+      Seq(
+        publishTo := Some("Artifactory Realm" at "http://oss.jfrog.org/artifactory/oss-snapshot-local"),
+        bintrayReleaseOnPublish := false,
+        // Only setting the credentials file if it exists (#52)
+        credentials := List(Path.userHome / ".bintray" / ".artifactory").filter(_.exists).map(Credentials(_)),
+        licenses := ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.txt")) :: Nil // this is required! otherwise Bintray will reject the code
+      )
+    else
+      Seq(
+        organization := "com.hootsuite",
+        pomExtra := <scm>
+          <url>https://github.com/hootsuite/akka-persistence-redis</url>
+          <connection>https://github.com/hootsuite/akka-persistence-redis</connection>
+        </scm>
+          <developers>
+            <developer>
+              <id>steve.song</id>
+              <name>Steve Song</name>
+              <url>http://www.hootsuite.com/</url>
+            </developer>
+          </developers>,
+        publishArtifact in Test := false,
+        homepage := Some(url("https://github.com/hootsuite/akka-persistence-redis")),
+        publishMavenStyle := true,
+        pomIncludeRepository := { _ => false },
+        resolvers += Resolver.url("akka-persistence-redis", url("http://dl.bintray.com/ssongvan/maven"))(Resolver.ivyStylePatterns),
+        licenses := ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.txt")) :: Nil // this is required! otherwise Bintray will reject the code
+      )
+}

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -1,4 +1,6 @@
 object Version {
+  val project = "0.1.0"
+  val scala = "2.11.7"
   val akka = "2.3.12"
   val play = "2.3.9"
   val rediscala = "1.4.0"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,3 @@
+resolvers += Resolver.jcenterRepo
+
+addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")


### PR DESCRIPTION
- Artifacts are hosted in https://bintray.com/ssongvan/maven/akka-persistence-redis/view
- This PR serves as groundwork for Travis-ci integration. 
- Taking inspirations from http://szimano.org/automatic-deployments-to-jfrog-oss-and-bintrayjcentermaven-central-via-travis-ci-from-sbt/