### PR TITLE
configure Redis from same config as the actor system

### DIFF
--- a/src/main/scala/com/hootsuite/akka/persistence/redis/DefaultRedisComponent.scala
+++ b/src/main/scala/com/hootsuite/akka/persistence/redis/DefaultRedisComponent.scala
@@ -1,15 +1,14 @@
 package com.hootsuite.akka.persistence.redis
 
 import akka.actor.ActorSystem
-import com.typesafe.config.ConfigFactory
 import redis.RedisClient
 
 trait DefaultRedisComponent {
   implicit val actorSystem: ActorSystem
 
-  private val config = ConfigFactory.load()
+  private val config = actorSystem.settings.config
   private val host = config.getString("redis.host")
   private val port = config.getInt("redis.port")
 
-  val redis = new RedisClient(host, port)
+  lazy val redis = new RedisClient(host, port)
 }


### PR DESCRIPTION
If any programmatic changes are made to config the plugin doesn't pick them up as it loads config fresh every time. If it instead uses the same config as the actor system it will inherit any config changes.