### PR TITLE
Add jcenterRepo resolver in build.sbt and update docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 # Development SNAPSHOT
 Nothing yet
 
+# 0.2.1
+- Add resolver for jcenter in build.sbt
+
 # 0.2.0
 - Bump rediscala version to 1.5.0
 - efc213 configure Redis from same config as the actor system

--- a/README.md
+++ b/README.md
@@ -11,13 +11,10 @@ Rest of methods are tested with the test harness included in this project.
 
 ## Quick start guide
 ### Installation
-plugins.sbt
-```
-resolvers += Resolver.jcenterRepo // Adds Bintray to resolvers for akka-persistence-redis and rediscala
-```
 build.sbt
 ```
-libraryDependencies ++= Seq("com.hootsuite" %% "akka-persistence-redis" % "0.2.0")
+resolvers += Resolver.jcenterRepo // Adds Bintray to resolvers for akka-persistence-redis and rediscala
+libraryDependencies ++= Seq("com.hootsuite" %% "akka-persistence-redis" % "0.2.1")
 ```
 ### Activation
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,8 @@ version := Version.project
 
 scalaVersion := Version.scala
 
+resolvers += Resolver.jcenterRepo
+
 libraryDependencies ++= Seq(
   "com.typesafe.akka"    %% "akka-contrib" % Version.akka,
   "com.etaty.rediscala"  %% "rediscala" % Version.rediscala,

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -1,5 +1,5 @@
 object Version {
-  val project = "0.2.0"
+  val project = "0.2.1"
   val scala = "2.11.7"
   val akka = "2.3.12"
   val play = "2.3.9"


### PR DESCRIPTION
As reported in https://github.com/hootsuite/akka-persistence-redis/issues/2 and https://github.com/hootsuite/akka-persistence-redis/issues/4, the project might not compile if resolver for jCenter is missing from build.sbt