### PR TITLE
Akka 2.4 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,9 @@ project/plugins/project/
 .scala_dependencies
 .worksheet
 
+# IntelliJ IDEA
+*.ipr
+*.iws
+
 # Mac OSX stuff
 .DS_STORE

--- a/build.sbt
+++ b/build.sbt
@@ -14,14 +14,14 @@ resolvers += Resolver.jcenterRepo
 
 libraryDependencies ++= Seq(
   "com.typesafe.akka"    %% "akka-contrib" % Version.akka,
-  "com.etaty.rediscala"  %% "rediscala" % Version.rediscala,
+  "com.github.etaty"     %% "rediscala" % Version.rediscala,
   "com.typesafe.play"    %% "play-json" % Version.play,
   "commons-codec"        %  "commons-codec"  % "1.9"
 )
 
 // Test dependencies
 libraryDependencies ++= Seq(
-  "com.typesafe.akka"    %% "akka-persistence-tck-experimental" % Version.akka % "test"
+  "com.typesafe.akka"    %% "akka-persistence-tck" % Version.akka % "test"
 )
 
 Settings.publishSettings

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -1,7 +1,7 @@
 object Version {
-  val project = "0.2.2"
+  val project = "0.3-SNAPSHOT"
   val scala = "2.11.7"
-  val akka = "2.3.12"
-  val play = "2.3.9"
-  val rediscala = "1.5.0"
+  val akka = "2.4.1"
+  val play = "2.4.6"
+  val rediscala = "1.6.0"
 }

--- a/src/main/scala/com/hootsuite/akka/persistence/redis/journal/RedisJournal.scala
+++ b/src/main/scala/com/hootsuite/akka/persistence/redis/journal/RedisJournal.scala
@@ -37,6 +37,13 @@ class RedisJournal extends AsyncWriteJournal with ActorLogging with DefaultRedis
     }
   })
 
+  /**
+   * Plugin API: asynchronously deletes all persistent messages up to `toSequenceNr`
+   * (inclusive).
+   *
+   * This call is protected with a circuit-breaker.
+   * Message deletion doesn't affect the highest sequence number of messages, journal must maintain the highest sequence number and never decrease it.
+   */
   override def asyncDeleteMessagesTo(persistenceId: String, toSequenceNr: Long): Future[Unit] =
     redis.zremrangebyscore(journalKey(persistenceId), Limit(-1), Limit(toSequenceNr)).map{_ => ()}
 

--- a/src/main/scala/com/hootsuite/akka/persistence/redis/snapshot/RedisSnapshotStore.scala
+++ b/src/main/scala/com/hootsuite/akka/persistence/redis/snapshot/RedisSnapshotStore.scala
@@ -64,6 +64,16 @@ class RedisSnapshotStore extends SnapshotStore with ActorLogging with DefaultRed
     }
   }
 
+  override def deleteAsync(metadata: SnapshotMetadata): Future[Unit] =
+    Future {
+      delete(metadata)
+    }
+
+  override def deleteAsync(persistenceId: String, criteria: SnapshotSelectionCriteria): Future[Unit] =
+    Future {
+      delete(persistenceId, criteria)
+    }
+
   /**
    * Plugin API: called after successful saving of a snapshot.
    *
@@ -89,6 +99,7 @@ class RedisSnapshotStore extends SnapshotStore with ActorLogging with DefaultRed
   def delete(persistenceId : String, criteria : SnapshotSelectionCriteria): Unit = {
     redis.zremrangebyscore(snapshotKey(persistenceId), Limit(-1L), Limit(criteria.maxSequenceNr))
   }
+
 }
 
 trait SnapshotExecutionContext {

--- a/src/test/scala/com/hootsuite/akka/persistence/redis/journal/RedisJournalSpec.scala
+++ b/src/test/scala/com/hootsuite/akka/persistence/redis/journal/RedisJournalSpec.scala
@@ -1,5 +1,6 @@
 package com.hootsuite.akka.persistence.redis.journal
 
+import akka.persistence.CapabilityFlag
 import akka.persistence.journal.JournalSpec
 import com.typesafe.config.ConfigFactory
 import redis.RedisClient
@@ -7,13 +8,15 @@ import redis.RedisClient
 /**
  * Akka Persistence Journal TCK tests provided by Akka
  */
-class RedisJournalSpec extends JournalSpec {
-
-  override lazy val config = ConfigFactory.parseString(
+class RedisJournalSpec extends JournalSpec(
+  config = ConfigFactory.parseString(
     """
       |akka.persistence.journal.plugin = "akka-persistence-redis.journal"
       |akka-persistence-redis.journal.class = "com.hootsuite.akka.persistence.redis.journal.RedisJournal"
     """.stripMargin)
+) {
+
+  override protected def supportsRejectingNonSerializableObjects: CapabilityFlag = true
 
   override def beforeAll() = {
     super.beforeAll()

--- a/src/test/scala/com/hootsuite/akka/persistence/redis/snapshot/RedisSnapshotSpec.scala
+++ b/src/test/scala/com/hootsuite/akka/persistence/redis/snapshot/RedisSnapshotSpec.scala
@@ -7,13 +7,13 @@ import redis.RedisClient
 /**
  * Akka Persistence Snapshot TCK tests provided by Akka
  */
-class RedisSnapshotSpec extends SnapshotStoreSpec {
-
-  override lazy val config = ConfigFactory.parseString(
+class RedisSnapshotSpec extends SnapshotStoreSpec(
+  config = ConfigFactory.parseString(
     """
       |akka.persistence.snapshot-store.plugin = "akka-persistence-redis.snapshot"
       |akka-persistence-redis.snapshot.class = "com.hootsuite.akka.persistence.redis.snapshot.RedisSnapshotStore"
     """.stripMargin)
+) {
 
   override def beforeAll() = {
     super.beforeAll()


### PR DESCRIPTION
This is an adaptation of the Journal and Snapshot stores to the Akka 2.4 all-async API. It passes all the TCK and I believe is behaving correctly.

Fixes #11 