### PR TITLE
Add support for Microsoft Azure Redis (authentication, max number of messages replayed) and allow to override key namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ From [rediscala](https://github.com/etaty/rediscala)
 redis {
   host = "localhost"
   port = 6379
+  # optional
+  password="topsecret"
 }
 ```
 
@@ -65,6 +67,7 @@ redis {
 ## Usage
 ### Redis keys
 Journal and snapshot use "journal:" and "snapshot:" as part of keys respectively as it is a good practice to create namespace for keys [reference](https://redislabs.com/blog/5-key-takeaways-for-developing-with-redis)
+The namespaces can be overriden using the akka-persistence-redis.journal.key-namespace and akka-persistence-redis.snapshot.key-namespace.
 
 ### How is data stored in Redis?
 In order to enforce ordering, journal entries and snapshots are inserted into [Sorted Set](http://redis.io/commands#sorted_set) and sorted by sequenceNr

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -21,7 +21,10 @@ akka-persistence-redis {
 
     # Dispatcher for fetching and replaying messages
     replay-dispatcher = "akka.persistence.dispatchers.default-replay-dispatcher"
-    }
+
+    # namespace used for the journal key
+    key-namespace = "journal"
+  }
 
   snapshot {
     # Class name of the plugin
@@ -31,5 +34,8 @@ akka-persistence-redis {
     plugin-dispatcher = "akka.persistence.dispatchers.default-plugin-dispatcher"
 
     snapshot-interval = 3600 s
+
+    # namespace used for the snapshot key
+    key-namespace = "snapshot"
   }
 }

--- a/src/main/scala/com/hootsuite/akka/persistence/redis/DefaultRedisComponent.scala
+++ b/src/main/scala/com/hootsuite/akka/persistence/redis/DefaultRedisComponent.scala
@@ -15,7 +15,12 @@ trait DefaultRedisComponent {
   } else {
     val host = config.getString("redis.host")
     val port = config.getInt("redis.port")
-    RedisClient(host, port)
+    val passwordConfig = "redis.password"
+    val password = config.hasPath(passwordConfig) match {
+      case true => Some(config.getString(passwordConfig))
+      case false => None
+    }
+    RedisClient(host, port, password=password)
   }
 
 }

--- a/src/main/scala/com/hootsuite/akka/persistence/redis/journal/RedisJournal.scala
+++ b/src/main/scala/com/hootsuite/akka/persistence/redis/journal/RedisJournal.scala
@@ -23,8 +23,15 @@ class RedisJournal extends AsyncWriteJournal with ActorLogging with DefaultRedis
    */
   override implicit lazy val actorSystem = context.system
 
+  private val config = actorSystem.settings.config
+
+  /**
+   * Get the journal key namespace from config
+   */
+  private val journalKeyNamespace = config.getString("akka-persistence-redis.journal.key-namespace")
+
   // Redis key namespace for journals
-  private def journalKey(persistenceId: String) = s"journal:$persistenceId"
+  private def journalKey(persistenceId: String) = s"$journalKeyNamespace:$persistenceId"
 
   private def highestSequenceNrKey(persistenceId: String) = s"${journalKey(persistenceId)}.highestSequenceNr"
 

--- a/src/main/scala/com/hootsuite/akka/persistence/redis/snapshot/RedisSnapshotStore.scala
+++ b/src/main/scala/com/hootsuite/akka/persistence/redis/snapshot/RedisSnapshotStore.scala
@@ -20,8 +20,12 @@ class RedisSnapshotStore extends SnapshotStore with ActorLogging with DefaultRed
    */
   override implicit lazy val actorSystem = context.system
 
+  private val config = actorSystem.settings.config
+
+  private val snapshotKeyNamespace =config.getString("akka-persistence-redis.snapshot.key-namespace")
+
   // Redis key namespace for snapshots
-  private def snapshotKey(persistenceId: String) = s"snapshot:$persistenceId"
+  private def snapshotKey(persistenceId: String) = s"$snapshotKeyNamespace:$persistenceId"
 
   /**
    * Plugin API: asynchronously loads a snapshot.


### PR DESCRIPTION
This is the first time I do a contribution on GitHub, so feel free to reject this :-). I can split the PR in several ones if that is more convenient. I have done this to be able to:
- use Microsoft Redis Cache
- have several Akka clusters using the same Redis instance (separating them with the key namespaces)

A link to the issue I encountered with the max number of messages to replay:
http://disq.us/p/1c3nvm2
