### PR TITLE
Add scala 2.12 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 # Development SNAPSHOT
 Nothing yet
 
+# 0.7.0
+- Scala 2.12 compatibility
+    - Replace play-json with spray-json
+    - Upgrade akka & rediscala
+    - Drop unused commons-codec dependency
+
 # 0.6.0
 - Support for Microsoft Azure Redis. Override the number of maximum number of messages to replay because the default is too big for Azure Redis.
 - Option to override key namespace with `journal.key-namespace` and `snapshot.key-namespace`

--- a/README.md
+++ b/README.md
@@ -5,22 +5,29 @@ This is a plugin for Akka Persistence that uses Redis as backend. It uses [redis
 It also depends on play-json for JSON serialization.
 
 ## Compatibility
-### Akka 2.4.x and Play 2.5.x
-Use versions from *0.6.0* for Akka 2.4.x and Play 2.5.x
+### Scala 2.12 and Akka 2.4.x
+Use versions from *0.7.0*
+```
+resolvers += Resolver.jcenterRepo // Adds Bintray to resolvers for akka-persistence-redis and rediscala
+libraryDependencies ++= Seq("com.hootsuite" %% "akka-persistence-redis" % "0.7.0")
+```
+
+### Scala 2.11, Akka 2.4.x and Play 2.5.x
+Use *0.6.0*
 ```
 resolvers += Resolver.jcenterRepo // Adds Bintray to resolvers for akka-persistence-redis and rediscala
 libraryDependencies ++= Seq("com.hootsuite" %% "akka-persistence-redis" % "0.6.0")
 ```
 
-### Akka 2.4.x and Play 2.4.x
-Use versions from *0.3.0* for Akka 2.4.x and Play 2.4.x
+### Scala 2.11, Akka 2.4.x and Play 2.4.x
+Use *0.5.0*
 ```
 resolvers += Resolver.jcenterRepo // Adds Bintray to resolvers for akka-persistence-redis and rediscala
 libraryDependencies ++= Seq("com.hootsuite" %% "akka-persistence-redis" % "0.3.0")
 ```
 
-### Akka 2.3.x
-Use versions up to *0.2.2* for Akka 2.3.x
+### Scala 2.11 and Akka 2.3.x
+Use *0.2.2*
 ```
 resolvers += Resolver.jcenterRepo // Adds Bintray to resolvers for akka-persistence-redis and rediscala
 libraryDependencies ++= Seq("com.hootsuite" %% "akka-persistence-redis" % "0.2.2")

--- a/build.sbt
+++ b/build.sbt
@@ -15,8 +15,7 @@ resolvers += Resolver.jcenterRepo
 libraryDependencies ++= Seq(
   "com.typesafe.akka"    %% "akka-contrib" % Version.akka,
   "com.github.etaty"     %% "rediscala" % Version.rediscala,
-  "com.typesafe.play"    %% "play-json" % Version.play,
-  "commons-codec"        %  "commons-codec"  % "1.9"
+  "io.spray"             %% "spray-json" % Version.sprayJson
 )
 
 // Test dependencies

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -1,7 +1,7 @@
 object Version {
-  val project = "0.6.0"
-  val scala = "2.11.7"
-  val akka = "2.4.4"
-  val play = "2.5.2"
-  val rediscala = "1.6.0"
+  val project = "0.7.0"
+  val scala = "2.12.1"
+  val akka = "2.4.12"
+  val sprayJson = "1.3.3"
+  val rediscala = "1.8.0"
 }

--- a/src/main/scala/com/hootsuite/akka/persistence/redis/journal/Journal.scala
+++ b/src/main/scala/com/hootsuite/akka/persistence/redis/journal/Journal.scala
@@ -2,8 +2,7 @@ package com.hootsuite.akka.persistence.redis.journal
 
 import akka.util.ByteString
 import com.hootsuite.akka.persistence.redis.SerializationException
-import org.apache.commons.codec.binary.Base64
-import play.api.libs.json._
+import spray.json._
 import redis.ByteStringFormatter
 
 /**
@@ -12,35 +11,17 @@ import redis.ByteStringFormatter
  */
 case class Journal(sequenceNr: Long, persistentRepr: Array[Byte], deleted: Boolean)
 
-object Journal {
-  implicit val byteArrayWrites = new Writes[Array[Byte]] {
-    override def writes(ba: Array[Byte]): JsValue = {
-      JsString(Base64.encodeBase64String(ba))
-    }
-  }
-
-  implicit val byteArrayReads = new Reads[Array[Byte]] {
-    override def reads(json: JsValue): JsResult[Array[Byte]] = json match {
-      case JsString(s) =>
-        try {
-          JsSuccess(Base64.decodeBase64(s))
-        } catch {
-          case _: Throwable => JsError("Cannot deserialize persistentRepr in Journal")
-        }
-      case _ => JsError("Cannot find deserializable JsValue")
-    }
-  }
-
-  implicit val fmt: Format[Journal] = Json.format[Journal]
+object Journal extends DefaultJsonProtocol {
+  implicit val fmt = jsonFormat3(Journal.apply)
 
   implicit val byteStringFormatter = new ByteStringFormatter[Journal] {
     override def serialize(data: Journal): ByteString = {
-      ByteString(Json.toJson(data).toString())
+      ByteString(data.toJson.toString)
     }
 
     override def deserialize(bs: ByteString): Journal = {
       try {
-        Json.parse(bs.utf8String).as[Journal]
+        bs.utf8String.parseJson.convertTo[Journal]
       } catch {
         case e: Exception => throw SerializationException("Error deserializing Journal.", e)
       }

--- a/src/main/scala/com/hootsuite/akka/persistence/redis/snapshot/SnapshotRecord.scala
+++ b/src/main/scala/com/hootsuite/akka/persistence/redis/snapshot/SnapshotRecord.scala
@@ -2,8 +2,7 @@ package com.hootsuite.akka.persistence.redis.snapshot
 
 import akka.util.ByteString
 import com.hootsuite.akka.persistence.redis.SerializationException
-import org.apache.commons.codec.binary.Base64
-import play.api.libs.json._
+import spray.json._
 import redis.ByteStringFormatter
 
 /**
@@ -12,35 +11,17 @@ import redis.ByteStringFormatter
  */
 case class SnapshotRecord(sequenceNr: Long, timestamp: Long, snapshot: Array[Byte])
 
-object SnapshotRecord {
-  implicit val byteArrayWrites = new Writes[Array[Byte]] {
-    override def writes(ba: Array[Byte]): JsValue = {
-      JsString(Base64.encodeBase64String(ba))
-    }
-  }
-
-  implicit val byteArrayReads = new Reads[Array[Byte]] {
-    override def reads(json: JsValue): JsResult[Array[Byte]] = json match {
-      case JsString(s) =>
-        try {
-          JsSuccess(Base64.decodeBase64(s))
-        } catch {
-          case _: Throwable => JsError("Cannot deserialize snapshot in SnapshotRecord")
-        }
-      case _ => JsError("Cannot find deserializable JsValue")
-    }
-  }
-
-  implicit val fmt: Format[SnapshotRecord] = Json.format[SnapshotRecord]
+object SnapshotRecord extends DefaultJsonProtocol {
+  implicit val fmt = jsonFormat3(SnapshotRecord.apply)
 
   implicit val byteStringFormatter = new ByteStringFormatter[SnapshotRecord] {
     override def serialize(data: SnapshotRecord): ByteString = {
-      ByteString(Json.toJson(data).toString())
+      ByteString(data.toJson.toString)
     }
 
     override def deserialize(bs: ByteString): SnapshotRecord = {
       try {
-        Json.parse(bs.utf8String).as[SnapshotRecord]
+        bs.utf8String.parseJson.convertTo[SnapshotRecord]
       } catch {
         case e: Exception => throw SerializationException("Error deserializing SnapshotRecord.", e)
       }


### PR DESCRIPTION
Addresses #26.

Turns out we also needed to switch `play-json` to `spray-json`, since Play is not yet compatible with Scala 2.12.