### PR TITLE
Fallback to `fromSequenceNr` instead of to `0L`

### DIFF
--- a/src/main/scala/com/hootsuite/akka/persistence/redis/journal/RedisJournal.scala
+++ b/src/main/scala/com/hootsuite/akka/persistence/redis/journal/RedisJournal.scala
@@ -142,7 +142,7 @@ class RedisJournal extends AsyncWriteJournal with ActorLogging with DefaultRedis
    */
   def asyncReadHighestSequenceNr(persistenceId : String, fromSequenceNr : Long) : Future[Long] = {
     redis.get(highestSequenceNrKey(persistenceId)).map {
-      highestSequenceNr => highestSequenceNr.map(_.utf8String.toLong).getOrElse(0L)
+      highestSequenceNr => highestSequenceNr.map(_.utf8String.toLong).getOrElse(fromSequenceNr)
     }
   }
 }


### PR DESCRIPTION
A fix to prevent overwriting lastSequenceNr of snapshot to `0L` in case that highest sequenceNr is not found in Redis db.

### Expected behavior (after this fix)

1. On snapshot loaded, lastSequenceNr is set to sequenceNr of the loaded snapshot.
2. akka-persistence-redis tries to load journal, but could not find highestSequenceNr in Redis db.
3. sequenceNr should be unchanged.

### Actual behavior (befor this fix)

1. On snapshot loaded, lastSequenceNr is set to sequenceNr of the loaded snapshot.
2. akka-persistence-redis tries to load journal, but could not find highestSequenceNr in Redis db.
3. sequenceNr has been overwritten to `0L` 