### PR TITLE
Bump Akka and Scala versions to current

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 # Development SNAPSHOT
 Nothing yet
 
+# 0.9.0
+- Upgrade Akka to 2.5 and Scala to 2.12.4
+
 # 0.8.0
 - Retry Redis operation when the server connection is lost
     - Only retries on NoConnectionException

--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@ This is a plugin for Akka Persistence that uses Redis as backend. It uses [redis
 It also depends on play-json for JSON serialization.
 
 ## Compatibility
+
+### Scala 2.12 and Akka 2.5.x
+Use versions from *0.9.0*
+```
+resolvers += Resolver.jcenterRepo // Adds Bintray to resolvers for akka-persistence-redis and rediscala
+libraryDependencies ++= Seq("com.hootsuite" %% "akka-persistence-redis" % "0.9.0")
+```
 ### Scala 2.12 and Akka 2.4.x
 Use versions from *0.7.0*
 ```

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -1,8 +1,8 @@
 object Version {
-  val project = "0.8.0"
-  val scala = "2.12.1"
-  val crossScala = Seq("2.11.8", "2.12.1")
-  val akka = "2.4.12"
+  val project = "0.9.0"
+  val scala = "2.12.4"
+  val crossScala = Seq("2.11.11", "2.12.4")
+  val akka = "2.5.9"
   val sprayJson = "1.3.3"
   val rediscala = "1.8.0"
   val dispatch = "0.12.0"


### PR DESCRIPTION
Since Akka 2.4 is [end of life](https://akka.io/blog/news/2018/01/11/akka-2.5.9-released-2.4.x-end-of-life), let's switch to 2.5. Akka 2.5 is binary compatible with 2.4, and tests for this project on 2.5 are all green, so this should be a smooth upgrade. Maybe it also warrants the project version change?